### PR TITLE
Update deps and fx from async flow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ the [ClojureScript mailing list](https://groups.google.com/forum/#!forum/clojure
 
 ## Pull requests
 
-**Create pull requests to the develop branch**, work will be merged onto master when it is ready to be released.
+**Create pull requests to the master branch**, work will be merged when it is ready to be released.
 
 ## Running tests
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,9 @@ dependencies:
     - npm install karma-cli -g
   cache_directories:
     - node_modules
+machine:
+  java:
+    version: oraclejdk8
 test:
   override:
     - lein karma-once

--- a/project.clj
+++ b/project.clj
@@ -37,11 +37,10 @@
                   ["vcs" "commit"]
                   ["vcs" "push"]]
 
-  :npm {:devDependencies [[karma                 "2.0.2"]
+  :npm {:devDependencies [[karma                 "1.0.0"]
                           [karma-cljs-test       "0.1.0"]
-                          [karma-chrome-launcher "2.2.0"]
-                          [karma-junit-reporter  "1.2.0"]
-                          [source-map-support    "0.5.4"]]}
+                          [karma-chrome-launcher "0.2.0"]
+                          [karma-junit-reporter  "0.3.8"]]}
 
   :cljsbuild {:builds [{:id           "test"
                         :source-paths ["test" "src"]

--- a/project.clj
+++ b/project.clj
@@ -2,15 +2,15 @@
   :description  "A re-frame effects handler for listening-for and then post-processing dispatched events."
   :url          "https://github.com/Day8/re-frame-forward-events-fx.git"
   :license      {:name "MIT"}
-  :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [org.clojure/clojurescript  "1.9.89"]
-                 [re-frame                   "0.8.0"]]
+  :dependencies [[org.clojure/clojure        "1.8.0"  :scope "provided"]
+                 [org.clojure/clojurescript  "1.9.89" :scope "provided"]
+                 [re-frame                   "0.10.5" :scope "provided"]]
 
   :profiles {:debug {:debug true}
-             :dev   {:dependencies [[karma-reporter     "1.0.1"]
-                                    [binaryage/devtools "0.8.1"]]
-                     :plugins      [[lein-ancient       "0.6.10"]
-                                    [lein-cljsbuild     "1.1.4"]
+             :dev   {:dependencies [[karma-reporter     "3.1.0"]
+                                    [binaryage/devtools "0.9.10"]]
+                     :plugins      [[lein-ancient       "0.6.15"]
+                                    [lein-cljsbuild     "1.1.7"]
                                     [lein-npm           "0.6.2"]
                                     [lein-shell         "0.5.0"]]}}
 
@@ -37,15 +37,16 @@
                   ["vcs" "commit"]
                   ["vcs" "push"]]
 
-  :npm {:dependencies [[karma                 "1.0.0"]
-                       [karma-cljs-test       "0.1.0"]
-                       [karma-chrome-launcher "0.2.0"]
-                       [karma-junit-reporter  "0.3.8"]]}
+  :npm {:devDependencies [[karma                 "2.0.2"]
+                          [karma-cljs-test       "0.1.0"]
+                          [karma-chrome-launcher "2.2.0"]
+                          [karma-junit-reporter  "1.2.0"]
+                          [source-map-support    "0.5.4"]]}
 
   :cljsbuild {:builds [{:id           "test"
                         :source-paths ["test" "src"]
                         :compiler     {:preloads             [devtools.preload]
-                                       :external-config      {:devtools/config {:features-to-install :all}}
+                                       :external-config      {:devtools/config {:features-to-install [:formatters :hints]}}
                                        :output-to     "run/compiled/browser/test.js"
                                        :source-map    true
                                        :output-dir    "run/compiled/browser/test"

--- a/src/day8/re_frame/forward_events_fx.cljs
+++ b/src/day8/re_frame/forward_events_fx.cljs
@@ -2,25 +2,41 @@
   (:require [re-frame.core :as re-frame]))
 
 
+(defn as-callback-pred
+  "Looks at the required-events items and returns a predicate which
+  will either
+  - match only the event-keyword if a keyword is supplied
+  - match the entire event vector if a collection is supplied
+  - returns a callback-pred if it is a fn"
+  [callback-pred]
+  (when callback-pred
+    (cond (fn? callback-pred) callback-pred
+          (keyword? callback-pred) (fn [[event-id _]]
+                                     (= callback-pred event-id))
+          (coll? callback-pred) (fn [event-v]
+                                  (= callback-pred event-v))
+          :else (throw
+                  (ex-info (str (pr-str callback-pred)
+                             " isn't an event predicate")
+                    {:callback-pred callback-pred})))))
+
+
 (re-frame/reg-fx
   :forward-events
-  (let [id->listen-fn     (atom {})
-        process-one-entry (fn [{:as m :keys [unregister register events dispatch-to]}]
+  (let [process-one-entry (fn [{:as m :keys [unregister register events dispatch-to]}]
                             (let [_ (assert (map? m) (str "re-frame: effects handler for :forward-events expected a map or a list of maps. Got: " m))
                                   _ (assert (or (= #{:unregister} (-> m keys set))
                                                 (= #{:register :events :dispatch-to} (-> m keys set))) (str "re-frame: effects handler for :forward-events given wrong map keys" (-> m keys set)))]
                               (if unregister
-                                (let [f (@id->listen-fn unregister)
-                                      _ (assert (some? f) (str ":forward-events  asked to unregister an unknown id: " unregister))]
-                                  (re-frame/remove-post-event-callback f)
-                                  (swap! id->listen-fn dissoc unregister))
-                                (let [post-event-callback-fn (fn [event-v _]
-                                                               (when (events (first event-v))
+                                (re-frame/remove-post-event-callback unregister)
+                                (let [events-preds           (map as-callback-pred events)
+                                      post-event-callback-fn (fn [event-v _]
+                                                               (when (some (fn [pred] (pred event-v))
+                                                                           events-preds)
                                                                  (re-frame/dispatch (conj dispatch-to event-v))))]
-                                  (re-frame/add-post-event-callback post-event-callback-fn)
-                                  (swap! id->listen-fn assoc register post-event-callback-fn)))))]
+                                  (re-frame/add-post-event-callback register post-event-callback-fn)))))]
     (fn [val]
       (cond
-        (map? val)        (process-one-entry val)
+        (map? val) (process-one-entry val)
         (sequential? val) (doall (map process-one-entry val))
-        :else (re-frame/console :error  ":forward-events expected a map or a list of maps, but got: " val)))))
+        :else (re-frame/console :error ":forward-events expected a map or a list of maps, but got: " val)))))


### PR DESCRIPTION
:async-flow fx had it's own conflicting version which doesn't use local atom and other improvements. Use same version here with the view to remove the conflicting version in :async-flow